### PR TITLE
Adapt to Android 13 notification permission changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.urbandroid.dontkillmyapp"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 33
         versionName "2.5"
 
@@ -31,8 +31,7 @@ android {
             signingConfig signingConfigs.release
         }
     }
-
-
+    namespace 'com.urbandroid.dontkillmyapp'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.urbandroid.dontkillmyapp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"
@@ -12,9 +13,10 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".RateActivity"></activity>
+        <activity android:name=".RateActivity" />
         <activity android:name=".ResultActivity" />
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/urbandroid/dontkillmyapp/service/BenchmarkService.kt
+++ b/app/src/main/java/com/urbandroid/dontkillmyapp/service/BenchmarkService.kt
@@ -100,7 +100,11 @@ class BenchmarkService : Service() {
 
         val i = Intent(this, ResultActivity::class.java)
         i.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        val pi = PendingIntent.getActivity(this, 4242, i, PendingIntent.FLAG_UPDATE_CURRENT)
+        val pi = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.getActivity(this, 4242, i, PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE))
+        } else {
+            PendingIntent.getActivity(this, 4242, i, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
 
         val notificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_FOREGROUND)
             .setSmallIcon(R.drawable.ic_dkma)
@@ -166,7 +170,11 @@ class BenchmarkService : Service() {
     private fun showFinishNotification() {
         val i = Intent(this, ResultActivity::class.java)
         i.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        val pi = PendingIntent.getActivity(this, 4242, i, PendingIntent.FLAG_UPDATE_CURRENT)
+        val pi = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.getActivity(this, 4242, i, PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE))
+        } else {
+            PendingIntent.getActivity(this, 4242, i, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
 
         val notificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_FOREGROUND)
             .setSmallIcon(R.drawable.ic_dkma)
@@ -190,7 +198,11 @@ class BenchmarkService : Service() {
     private fun getAlarmIntent() : PendingIntent {
         val i = Intent(ACTION_ALARM)
         i.setPackage(packageName)
-        return PendingIntent.getBroadcast(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.getBroadcast(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE))
+        } else {
+            PendingIntent.getBroadcast(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
     }
 
     fun scheduleAlarm() {

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.30"
+    ext.kotlin_version = '1.6.20'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
Although Android 13 now allow the app to automatically request the POST_NOTIFICATION permission when starting foreground BenchmarkService, the notification won't show up for the time user agree to permit the permission. So, this commit makes BenchmarkService to only start after closing notification permission dialog. And it won't break normal situations when notification permission is already granted / denied.

And there are some other stuff for making it compiled for Android 13. Like update kotlin & gradle, setting PendingIntent Mutablility Flags